### PR TITLE
BI-13580 - add non-sensitive consumer config variables for advanced

### DIFF
--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -1,8 +1,8 @@
-environment = "cidev"
-aws_profile = "development-eu-west-2"
+environment = "live"
+aws_profile = "live-eu-west-2"
 
 # service configs
-log_level = "debug"
+log_level = "trace"
 human_log = "1"
 
 backoff_delay = "30000"

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -2,5 +2,14 @@ environment = "staging"
 aws_profile = "staging-eu-west-2"
 
 # service configs
-use_set_environment_files = true
 log_level = "trace"
+human_log = "1"
+
+backoff_delay = "30000"
+concurrent_listener_instances = "1"
+group_id = "advanced-company-search-consumer-group"
+max_attempts = "4"
+server_port = "8080"
+topic = "stream-company-profile"
+
+use_set_environment_files = true


### PR DESCRIPTION
Mirroring @VaughanJackson123 PR for alphabetical-company-search-consumer [here](https://github.com/companieshouse/alphabetical-company-search-consumer/pull/16)

Added vars for up to live and also added config variables in advance of the completion of [BI-13583](https://companieshouse.atlassian.net/browse/BI-13583) work to consume stream-company-profile message

