### PR TITLE
BI-13582: Bump spring-web to 6.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>6.1.4</version>
+            <version>6.1.6</version>
         </dependency>
         <!-- Avoid potential security vulnerabilities CVE-2024-26308 and CVE-2024-25710. -->
         <dependency>


### PR DESCRIPTION
This resolves the outstanding security warning in the pipeline.