### PR TITLE
DSND-2980: Add default backoff delay

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVER_URL}
 consumer.topic=${TOPIC}
 consumer.group_id=${GROUP_ID}
 consumer.max_attempts=${MAX_ATTEMPTS}
-consumer.backoff_delay=${BACKOFF_DELAY}
+consumer.backoff_delay=${BACKOFF_DELAY:30000}
 consumer.concurrency=${CONCURRENT_LISTENER_INSTANCES}
 
 invalid_message_topic=${TOPIC}-${GROUP_ID}-invalid


### PR DESCRIPTION
This PR is to add a default backoff delay as a precaution.

[DSND-2980](https://companieshouse.atlassian.net/browse/DSND-2980)

[DSND-2980]: https://companieshouse.atlassian.net/browse/DSND-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ