### PR TITLE
Increase CPU, memory and scale out values

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -72,6 +72,7 @@ module "ecs-service" {
   service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
   service_scaledown_schedule         = var.service_scaledown_schedule
   service_scaleup_schedule           = var.service_scaleup_schedule
+  service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
   use_capacity_provider              = var.use_capacity_provider
   use_fargate                        = var.use_fargate
   fargate_subnets                    = local.application_subnet_ids

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -8,3 +8,7 @@ use_set_environment_files = true
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
+
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -3,3 +3,7 @@ aws_profile = "live-eu-west-2"
 
 # service configs
 use_set_environment_files = true
+
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -8,3 +8,7 @@ use_set_environment_files = true
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
+
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -124,6 +124,12 @@ variable "service_scaleup_schedule" {
   default     = ""
 }
 
+variable "service_autoscale_scale_out_cooldown" {
+  type        = number
+  description = "Cooldown in seconds for ECS Service scale out (add more tasks)"
+  default     = 300
+}
+
 # ----------------------------------------------------------------------
 # Cloudwatch alerts
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Increase cpu memory and scale out values to attempt to prevent constant recycling and timeouts to give the service longer to reach a healthy state and to avoid potentially timing out on apply jobs.