### PR TITLE
Kaf 549 upgrade to spring boot 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit: clean
-	mvn test -DexcludedGroups="integration-test"
+	mvn verify -DexcludedGroups="integration-test"
 
 .PHONY: test-integration
 test-integration: clean
-	mvn test -Dgroups="unit-test, integration-test"
+	mvn verify -Dgroups="unit-test, integration-test"
 
 .PHONY: package
 package:

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,4 @@ dist: clean package
 publish:
 	mvn jar:jar deploy:deploy
 
-.PHONY: sonar
-sonar:
-	mvn sonar:sonar
-
-.PHONY: sonar-pr-analysis
-sonar-pr-analysis:
-	mvn sonar:sonar -P sonar-pr-analysis
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ In order to build `advanced-company-search-consumer` locally you will need the f
 
 ## Endpoints
 
-| Path                                                  | Method | Description                                                         |
-|-------------------------------------------------------|--------|---------------------------------------------------------------------|
-| *`/advanced-company-search-consumer/healthcheck`* | GET    | Returns HTTP OK (`200`) to indicate a healthy application instance. |
+| Path                                                | Method | Description                                                         |
+|-----------------------------------------------------|--------|---------------------------------------------------------------------|
+| *`/advanced-company-search-consumer/healthcheck`*   | GET    | Returns HTTP OK (`200`) to indicate a healthy application instance. |

--- a/pom.xml
+++ b/pom.xml
@@ -33,17 +33,7 @@
 
         <!-- Docker -->
         <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
-
-        <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
-        <sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
-        <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
-        <sonar.login></sonar.login>
-        <sonar.password></sonar.password>
-        <sonar.projectKey>uk.gov.companieshouse:advanced-company-search-consumer</sonar.projectKey>
-        <sonar.projectName>advanced-company-search-consumer</sonar.projectName>
-
-
-        <sonar.jacoco.reports>${project.build.directory}/site</sonar.jacoco.reports>
+        <jacoco.reports.directory>${project.build.directory}/site</jacoco.reports.directory>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <maven-test-plugin.version>3.5.5</maven-test-plugin.version>
         <maven-surefire-plugin.version>${maven-test-plugin.version}</maven-surefire-plugin.version>
@@ -53,7 +43,7 @@
         <junit-platform.version>1.13.4</junit-platform.version>
         <avro.version>1.12.1</avro.version>
 
-        <ch-boms.version>0.1.15</ch-boms.version>
+        <ch-boms.version>0.1.16</ch-boms.version>
 
         <!-- Sonar Exclusions -->
         <sonar.exclusions>
@@ -64,6 +54,7 @@
         </jib-maven-plugin.image>
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <commons-compress.version>1.26.0</commons-compress.version>
+        <commons-io.version>2.22.0</commons-io.version>
     </properties>
 
     <dependencyManagement>
@@ -82,14 +73,6 @@
                 <groupId>uk.gov.companieshouse</groupId>
                 <artifactId>ch-test-bom</artifactId>
                 <version>${ch-boms.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -288,6 +271,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -336,7 +320,7 @@
                         <configuration>
                             <propertyName>surefireArgLine</propertyName>
                             <!-- Sets the path to the file which contains the execution model. -->
-                            <destFile>${sonar.jacoco.reports}/jacoco.exec</destFile>
+                            <destFile>${jacoco.reports.directory}/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -347,9 +331,9 @@
                         </goals>
                         <configuration>
                             <!-- Sets the path to the file which contains the execution data. -->
-                            <dataFile>${sonar.jacoco.reports}/jacoco.exec</dataFile>
+                            <dataFile>${jacoco.reports.directory}/jacoco.exec</dataFile>
                             <!-- Sets the output directory for the code coverage report. -->
-                            <outputDirectory>${sonar.jacoco.reports}/jacoco</outputDirectory>
+                            <outputDirectory>${jacoco.reports.directory}/jacoco</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
@@ -419,7 +403,6 @@
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>${sonar-maven-plugin.version}</version>
             </plugin>
-
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
         <sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
+        <sonar.login></sonar.login>
+        <sonar.password></sonar.password>
+        <sonar.projectKey>uk.gov.companieshouse:advanced-company-search-consumer</sonar.projectKey>
+        <sonar.projectName>advanced-company-search-consumer</sonar.projectName>
+
 
         <sonar.jacoco.reports>${project.build.directory}/site</sonar.jacoco.reports>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
@@ -367,10 +372,82 @@
                 </executions>
             </plugin>
 
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-failsafe-plugin</artifactId>-->
+<!--                <version>${maven-failsafe-plugin.version}</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <goals>-->
+<!--                            <goal>integration-test</goal>-->
+<!--                            <goal>verify</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <configuration>-->
+<!--                    <argLine>-->
+<!--                        -Dfile.encoding=UTF-8-->
+<!--                        ${failsafeArgLine}-->
+<!--                    </argLine>-->
+<!--                    &lt;!&ndash; See SUREFIRE-1198 &ndash;&gt;-->
+<!--                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>-->
+<!--                    <properties>-->
+<!--                        <configurationParameters>-->
+<!--                            cucumber.junit-platform.naming-strategy=long-->
+<!--                        </configurationParameters>-->
+<!--                        <property>-->
+<!--                            <name>listener</name>-->
+<!--                            <value>org.sonar.java.jacoco.JUnitListener</value>-->
+<!--                        </property>-->
+<!--                    </properties>-->
+<!--                    <skipITs>${skip.integration.tests}</skipITs>-->
+<!--                    <includes>-->
+<!--                        <include>**/Runner.java</include>-->
+<!--                    </includes>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
+
+<!--            &lt;!&ndash; Unit Testing &ndash;&gt;-->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-surefire-plugin</artifactId>-->
+<!--                <version>${maven-surefire-plugin.version}</version>-->
+<!--                <configuration>-->
+<!--                    <argLine>-->
+<!--                        -Dfile.encoding=UTF-8-->
+<!--                        ${surefireArgLine}-->
+<!--                        &#45;&#45;add-opens java.base/java.lang=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/java.util=ALL-UNNAMED-->
+<!--                    </argLine>-->
+<!--                    <skipTests>${skip.unit.tests}</skipTests>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
+
+
+
+
+
+
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <skipTests>${skipTests}</skipTests>
+                    <excludes>
+                        <exclude>**/Runner.java</exclude>
+                    </excludes>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven-failsafe-plugin.version}</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -380,20 +457,12 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <argLine>
-                        -Dfile.encoding=UTF-8
-                        ${failsafeArgLine}
-                    </argLine>
                     <!-- See SUREFIRE-1198 -->
                     <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                     <properties>
                         <configurationParameters>
                             cucumber.junit-platform.naming-strategy=long
                         </configurationParameters>
-                        <property>
-                            <name>listener</name>
-                            <value>org.sonar.java.jacoco.JUnitListener</value>
-                        </property>
                     </properties>
                     <skipITs>${skip.integration.tests}</skipITs>
                     <includes>
@@ -401,22 +470,16 @@
                     </includes>
                 </configuration>
             </plugin>
-
-            <!-- Unit Testing -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <argLine>
-                        -Dfile.encoding=UTF-8
-                        ${surefireArgLine}
-                        --add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                    </argLine>
-                    <skipTests>${skip.unit.tests}</skipTests>
-                </configuration>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar-maven-plugin.version}</version>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
         <relativePath/>
     </parent>
     <artifactId>advanced-company-search-consumer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -419,5 +419,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <skipTests>${skipTests}</skipTests>
+                    <skipTests>${skip.unit.tests}</skipTests>
                     <excludes>
                         <exclude>**/Runner.java</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,8 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>3.5.10</spring-boot-maven-plugin.version>
-        <spring-framework.version>6.2.19</spring-framework.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <test-containers.version>1.19.4</test-containers.version>
         <structured-logging.version>3.0.40</structured-logging.version>
@@ -66,14 +65,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- spring-framework BOM to align all Spring Framework dependencies to the same version -->
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-framework-bom</artifactId>
-                <version>${spring-framework.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -312,6 +303,11 @@
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-lambda</artifactId>
             <version>${system-lambda.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,6 @@
         <kafka-clients.version>3.9.2</kafka-clients.version>
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,
-			${project.basedir}/target/site/jacoco-it/jacoco.xml
-		</sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
 
         <!-- Docker -->
         <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
@@ -41,17 +37,28 @@
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
         <sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
-		<sonar.login></sonar.login>
-		<sonar.password></sonar.password>
-		<sonar.projectKey>uk.gov.companieshouse:advanced-company-search-consumer</sonar.projectKey>
-		<sonar.projectName>advanced-company-search-consumer</sonar.projectName>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+
+        <sonar.jacoco.reports>${project.build.directory}/site</sonar.jacoco.reports>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <maven-test-plugin.version>3.5.5</maven-test-plugin.version>
+        <maven-surefire-plugin.version>${maven-test-plugin.version}</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>${maven-test-plugin.version}</maven-failsafe-plugin.version>
+
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <junit-platform.version>1.13.4</junit-platform.version>
         <avro.version>1.12.1</avro.version>
 
         <ch-boms.version>0.1.15</ch-boms.version>
+
+        <!-- Sonar Exclusions -->
+        <sonar.exclusions>
+            **/Application.java
+        </sonar.exclusions>
+
+        <jib-maven-plugin.image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21
+        </jib-maven-plugin.image>
+        <mockito-inline.version>5.2.0</mockito-inline.version>
+        <commons-compress.version>1.26.0</commons-compress.version>
     </properties>
 
     <dependencyManagement>
@@ -185,7 +192,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>${commons-compress.version}</version>
         </dependency>
 
         <dependency>
@@ -249,7 +256,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>5.2.0</version>
+            <version>${mockito-inline.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -300,30 +307,70 @@
                 <version>${jib-maven-plugin.version}</version>
                 <configuration>
                     <from>
-                        <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21</image>
+                        <image>${jib-maven-plugin.image}</image>
                     </from>
                 </configuration>
             </plugin>
 
+            <!-- JaCoCo Maven Plugin for Code Coverage -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
                 <configuration>
-                    <skipTests>${skip.unit.tests}</skipTests>
                     <excludes>
-                        <exclude>**/Runner.java</exclude>
+                        <exclude>**/Application.class</exclude>
                     </excludes>
-                    <argLine>
-                        --add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                    </argLine>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>surefireArgLine</propertyName>
+                            <!-- Sets the path to the file which contains the execution model. -->
+                            <destFile>${sonar.jacoco.reports}/jacoco.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution data. -->
+                            <dataFile>${sonar.jacoco.reports}/jacoco.exec</dataFile>
+                            <!-- Sets the output directory for the code coverage report. -->
+                            <outputDirectory>${sonar.jacoco.reports}/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>failsafeArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${maven-failsafe-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -333,12 +380,20 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <argLine>
+                        -Dfile.encoding=UTF-8
+                        ${failsafeArgLine}
+                    </argLine>
                     <!-- See SUREFIRE-1198 -->
                     <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                     <properties>
                         <configurationParameters>
                             cucumber.junit-platform.naming-strategy=long
                         </configurationParameters>
+                        <property>
+                            <name>listener</name>
+                            <value>org.sonar.java.jacoco.JUnitListener</value>
+                        </property>
                     </properties>
                     <skipITs>${skip.integration.tests}</skipITs>
                     <includes>
@@ -346,14 +401,21 @@
                     </includes>
                 </configuration>
             </plugin>
+
+            <!-- Unit Testing -->
             <plugin>
-              <groupId>org.jacoco</groupId>
-              <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-              <groupId>org.sonarsource.scanner.maven</groupId>
-              <artifactId>sonar-maven-plugin</artifactId>
-              <version>${sonar-maven-plugin.version}</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <argLine>
+                        -Dfile.encoding=UTF-8
+                        ${surefireArgLine}
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                    <skipTests>${skip.unit.tests}</skipTests>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,20 +18,13 @@
         <maven.compiler.target>21</maven.compiler.target>
         <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>3.5.10</spring-boot-maven-plugin.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
         <test-containers.version>1.19.4</test-containers.version>
-        <structured-logging.version>3.0.40</structured-logging.version>
-        <api-sdk-manager-java-library.version>3.0.22</api-sdk-manager-java-library.version>
         <private-api-sdk-java.version>6.0.6</private-api-sdk-java.version>
-        <kafka-models.version>3.0.31</kafka-models.version>
-        <ch-kafka.version>3.0.6</ch-kafka.version>
         <system-lambda.version>1.2.1</system-lambda.version>
         <spring-kafka.version>3.3.13</spring-kafka.version>
         <jose4j.version>0.9.6</jose4j.version>
-        <log4j-to-slf4j.version>2.25.4</log4j-to-slf4j.version>
-        <log4j-api.version>2.25.4</log4j-api.version>
-        <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
-        <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
+        <log4j-to-slf4j.version>2.25.5</log4j-to-slf4j.version>
+        <log4j-api.version>2.25.5</log4j-api.version>
         <netty.version>4.2.15.Final</netty.version>
         <opentelemetry-api.version>1.63.0</opentelemetry-api.version>
         <kafka-clients.version>3.9.2</kafka-clients.version>
@@ -57,10 +50,30 @@
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <junit-platform.version>1.13.4</junit-platform.version>
         <avro.version>1.12.1</avro.version>
+
+        <ch-boms.version>0.1.15</ch-boms.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Import CH BOM first so CH-approved versions (CVE overrides) take precedence -->
+            <dependency>
+                <groupId>uk.gov.companieshouse</groupId>
+                <artifactId>ch-dependency-bom</artifactId>
+                <version>${ch-boms.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Optionally import test BOM for managed test dependency versions -->
+            <dependency>
+                <groupId>uk.gov.companieshouse</groupId>
+                <artifactId>ch-test-bom</artifactId>
+                <version>${ch-boms.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
@@ -94,43 +107,6 @@
                 <artifactId>log4j-to-slf4j</artifactId>
                 <version>${log4j-to-slf4j.version}</version>
             </dependency>
-            <!-- CVE-2026-41293(9.8), CVE-2026-41284(7.5), CVE-2026-43513(7.5), CVE-2026-43512(9.8) -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat-embed-core.version}</version>
-            </dependency>
-            <!-- CVE-2026-41293(9.8), CVE-2026-41284(7.5), CVE-2026-43513(7.5), CVE-2026-43512(9.8) -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat-embed-websocket.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-api</artifactId>
-                <version>${opentelemetry-api.version}</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- CVE-2026-33558(5.3) -->
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>${kafka-clients.version}</version>
-            </dependency>
-            <!-- CVE-2025-33042 -->
-            <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>${avro.version}</version>
-            </dependency>
-            <!-- CVE-2024-29371 -->
-            <dependency>
-                <groupId>org.bitbucket.b_c</groupId>
-                <artifactId>jose4j</artifactId>
-                <version>${jose4j.version}</version>
-                <scope>compile</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -151,7 +127,6 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
-            <version>${structured-logging.version}</version>
             <exclusions>
                 <exclusion>
                     <!-- Exclude logback to prevent multiple SLF4J binding warning -->
@@ -168,7 +143,6 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>
-            <version>${api-sdk-manager-java-library.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>
@@ -188,12 +162,10 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>kafka-models</artifactId>
-            <version>${kafka-models.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>ch-kafka</artifactId>
-            <version>${ch-kafka.version}</version>
         </dependency>
 
         <!--Aspect Dependencies-->
@@ -205,18 +177,9 @@
             <artifactId>aspectjtools</artifactId>
             <groupId>org.aspectj</groupId>
         </dependency>
-
-        <!-- Avoid pseudo(?) security vulnerability CVE-2023-35116. -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <!--CVE-2025-48924-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <!-- Avoid potential security vulnerabilities CVE-2024-26308 and CVE-2024-25710. -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,6 @@
         <jose4j.version>0.9.6</jose4j.version>
         <log4j-to-slf4j.version>2.25.5</log4j-to-slf4j.version>
         <log4j-api.version>2.25.5</log4j-api.version>
-        <netty.version>4.2.15.Final</netty.version>
-        <opentelemetry-api.version>1.63.0</opentelemetry-api.version>
         <kafka-clients.version>3.9.2</kafka-clients.version>
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -371,64 +371,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-failsafe-plugin</artifactId>-->
-<!--                <version>${maven-failsafe-plugin.version}</version>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <goals>-->
-<!--                            <goal>integration-test</goal>-->
-<!--                            <goal>verify</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--                <configuration>-->
-<!--                    <argLine>-->
-<!--                        -Dfile.encoding=UTF-8-->
-<!--                        ${failsafeArgLine}-->
-<!--                    </argLine>-->
-<!--                    &lt;!&ndash; See SUREFIRE-1198 &ndash;&gt;-->
-<!--                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>-->
-<!--                    <properties>-->
-<!--                        <configurationParameters>-->
-<!--                            cucumber.junit-platform.naming-strategy=long-->
-<!--                        </configurationParameters>-->
-<!--                        <property>-->
-<!--                            <name>listener</name>-->
-<!--                            <value>org.sonar.java.jacoco.JUnitListener</value>-->
-<!--                        </property>-->
-<!--                    </properties>-->
-<!--                    <skipITs>${skip.integration.tests}</skipITs>-->
-<!--                    <includes>-->
-<!--                        <include>**/Runner.java</include>-->
-<!--                    </includes>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
-
-<!--            &lt;!&ndash; Unit Testing &ndash;&gt;-->
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                <version>${maven-surefire-plugin.version}</version>-->
-<!--                <configuration>-->
-<!--                    <argLine>-->
-<!--                        -Dfile.encoding=UTF-8-->
-<!--                        ${surefireArgLine}-->
-<!--                        &#45;&#45;add-opens java.base/java.lang=ALL-UNNAMED-->
-<!--                        &#45;&#45;add-opens java.base/java.util=ALL-UNNAMED-->
-<!--                    </argLine>-->
-<!--                    <skipTests>${skip.unit.tests}</skipTests>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
-
-
-
-
-
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -445,17 +387,6 @@
                         --add-opens java.base/java.util=ALL-UNNAMED
                     </argLine>
                 </configuration>
-
-
-<!--                                <configuration>-->
-<!--                                    <argLine>-->
-<!--                                        -Dfile.encoding=UTF-8-->
-<!--                                        ${surefireArgLine}-->
-<!--                                        &#45;&#45;add-opens java.base/java.lang=ALL-UNNAMED-->
-<!--                                        &#45;&#45;add-opens java.base/java.util=ALL-UNNAMED-->
-<!--                                    </argLine>-->
-<!--                                    <skipTests>${skip.unit.tests}</skipTests>-->
-<!--                                </configuration>-->
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -482,10 +413,6 @@
                         <include>**/Runner.java</include>
                     </includes>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -396,11 +396,6 @@
                     </includes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.sonarsource.scanner.maven</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-                <version>${sonar-maven-plugin.version}</version>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -434,15 +434,28 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <skipTests>${skipTests}</skipTests>
+                    <skipTests>${skip.unit.tests}</skipTests>
                     <excludes>
                         <exclude>**/Runner.java</exclude>
                     </excludes>
                     <argLine>
+                        -Dfile.encoding=UTF-8
+                        ${surefireArgLine}
                         --add-opens java.base/java.lang=ALL-UNNAMED
                         --add-opens java.base/java.util=ALL-UNNAMED
                     </argLine>
                 </configuration>
+
+
+<!--                                <configuration>-->
+<!--                                    <argLine>-->
+<!--                                        -Dfile.encoding=UTF-8-->
+<!--                                        ${surefireArgLine}-->
+<!--                                        &#45;&#45;add-opens java.base/java.lang=ALL-UNNAMED-->
+<!--                                        &#45;&#45;add-opens java.base/java.util=ALL-UNNAMED-->
+<!--                                    </argLine>-->
+<!--                                    <skipTests>${skip.unit.tests}</skipTests>-->
+<!--                                </configuration>-->
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.10</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>${spring-boot-dependencies.version}</spring-boot-maven-plugin.version>
         <test-containers.version>1.19.4</test-containers.version>
         <private-api-sdk-java.version>6.0.6</private-api-sdk-java.version>
         <system-lambda.version>1.2.1</system-lambda.version>
@@ -271,6 +271,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/CompanyProfileDeserialiser.java
+++ b/src/main/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/CompanyProfileDeserialiser.java
@@ -1,13 +1,14 @@
 package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.AdvancedCompanySearchConsumerApplication.NAMESPACE;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.exception.NonRetryableException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.AdvancedCompanySearchConsumerApplication.NAMESPACE;
 
 @Component
 public class CompanyProfileDeserialiser {
@@ -23,7 +24,7 @@ public class CompanyProfileDeserialiser {
     public CompanyProfileApi deserialiseCompanyProfile(String data) {
         try {
             return objectMapper.readValue(data, CompanyProfileApi.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             logger.errorContext( "Unable to parse message payload data", e, null);
             throw new NonRetryableException("Unable to parse message payload data", e);
         }

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/AdvancedIndexUpdaterServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/AdvancedIndexUpdaterServiceTest.java
@@ -1,6 +1,19 @@
 package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
 
-import org.apache.kafka.common.security.oauthbearer.internals.secured.UnretryableException;
+import static org.apache.commons.io.IOUtils.resourceToString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.DELETE_PAYLOAD;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.WRONG_EVENT_TYPE_PAYLOAD;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,20 +29,6 @@ import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
-import static org.apache.commons.io.IOUtils.resourceToString;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.DELETE_PAYLOAD;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.WRONG_EVENT_TYPE_PAYLOAD;
 
 @ExtendWith(MockitoExtension.class)
 class AdvancedIndexUpdaterServiceTest {
@@ -82,7 +81,7 @@ class AdvancedIndexUpdaterServiceTest {
 
     @Test
     @DisplayName("processMessage() correctly calls the delete service when event.type is 'deleted'")
-    public void testProcessMessage_DeletedMessageType() throws ApiErrorResponseException, URIValidationException {
+    void testProcessMessage_DeletedMessageType() throws ApiErrorResponseException, URIValidationException {
         // Given
         when(serviceParameters.getData()).thenReturn(DELETE_PAYLOAD);
 

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/CompanyProfileDeserialiserTest.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/CompanyProfileDeserialiserTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -32,7 +33,7 @@ class CompanyProfileDeserialiserTest {
         when(mockObjectMapper.readValue(testData, CompanyProfileApi.class))
                 .thenReturn(mock(CompanyProfileApi.class));
 
-        deserialiser.deserialiseCompanyProfile("Dummy Data");
+        assertNotNull(deserialiser.deserialiseCompanyProfile("Dummy Data"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/CompanyProfileDeserialiserTest.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/CompanyProfileDeserialiserTest.java
@@ -1,0 +1,52 @@
+package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.companieshouse.advancedcompanysearchconsumer.exception.NonRetryableException;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+
+@ExtendWith(MockitoExtension.class)
+class CompanyProfileDeserialiserTest {
+
+    @Mock
+    private ObjectMapper mockObjectMapper;
+
+    @InjectMocks
+    private CompanyProfileDeserialiser deserialiser;
+
+    @Test
+    void whenDeserialisationSuccessful_thenReturnCompanyProfileApi() throws JacksonException {
+        final var testData = "Dummy Data";
+
+        when(mockObjectMapper.readValue(testData, CompanyProfileApi.class))
+                .thenReturn(mock(CompanyProfileApi.class));
+
+        deserialiser.deserialiseCompanyProfile("Dummy Data");
+    }
+
+    @Test
+    void whenDeserialisationFails_thenThrowsException() throws JacksonException {
+        final var testData = "Dummy Data";
+        final var mockException = mock(JacksonException.class);
+
+        when(mockObjectMapper.readValue(testData, CompanyProfileApi.class))
+                .thenThrow(mockException);
+
+        final var exception = assertThrows(NonRetryableException.class, () ->
+            deserialiser.deserialiseCompanyProfile(testData));
+
+        assertThat(exception.getMessage()).isEqualTo("Unable to parse message payload data");
+        assertThat(exception.getCause()).isEqualTo(mockException);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/HealthCheckTest.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/service/HealthCheckTest.java
@@ -1,17 +1,17 @@
 package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.config.TestKafkaConfig;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @SpringBootTest

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/utils/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/utils/TestConstants.java
@@ -4,7 +4,7 @@ import static java.util.Collections.emptyList;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import uk.gov.companieshouse.stream.EventRecord;
 import uk.gov.companieshouse.stream.ResourceChangedData;
 


### PR DESCRIPTION
Upgraded to Spring Boot 4.

* Uplifted Spring Boot and Spring Framework versions
* Added spring-boot-webmvc-test dependency
* Amended deserialiser to import from Jackson 3 packages
* Caught JacksonException in deserialiser for Jackson 3
* Amended TestConstants to use "real" IOUtils class rather than shaded version no longer provided
* Imported jUnit5 assertThrows
* Added correct AutoConfigureMockMvc import to HealthCheckTest
* Amended files to follow coding guidelines - statics first

Aligned makefile test with pom to use mvn verify.

Addressed security vulnerabilities.

* Uplifted log4j version numbers
* Introduced ch-boms
* Removed old dependencies no longer needed
* Added tests for CompanyProfileDeserialiser
* Added commons-io test dependency
* Aligned Spring boot and maven plugin versions to 4.1.0
* Corrected surefire to look for skip.unit.tests not skipTests

Removed version / property from following dependencies brought in by ch-boms.

* structured-logging
* api-sdk-manager-java
* ch-kafka
* kafka-models
* commons-lang3