### PR TITLE
Add conifgs for dual deployment

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -4,13 +4,15 @@ locals {
   name_prefix                = "${local.stack_name}-${var.environment}"
   global_prefix              = "global-${var.environment}"
   service_name               = "advanced-company-search-consumer"
+  service_name_old_kafka     = "advanced-company-search-consumer-old-kafka"
   container_port             = 8080
   docker_repo                = "advanced-company-search-consumer"
   kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority  = 22
   lb_listener_paths          = ["/advanced-company-search-consumer/*"]
   s3_config_bucket           = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
-  app_environment_filename   = "advanced-company-search-consumer.env"
+  app_environment_filename          = "advanced-company-search-consumer.env"
+  app_environment_filename_old_kafka = "advanced-company-search-consumer-old-kafka.env"
   use_set_environment_files  = var.use_set_environment_files
   application_subnet_ids     = data.aws_subnets.application.ids
   application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -86,3 +86,64 @@ module "ecs-service" {
   app_environment_filename  = local.app_environment_filename
   use_set_environment_files = local.use_set_environment_files
 }
+
+module "ecs-service-old-kafka" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.294"
+  count  = var.create_old_kafka_service ? 1 : 0
+
+  # Environmental configuration
+  environment             = var.environment
+  aws_region              = var.aws_region
+  aws_profile             = var.aws_profile
+  vpc_id                  = data.aws_vpc.vpc.id
+  ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
+  task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+
+  # Load balancer configuration
+  batch_service = true
+
+  # ECS Task container health check
+  use_task_container_healthcheck    = true
+  healthcheck_path                  = local.healthcheck_path
+  healthcheck_matcher               = local.healthcheck_matcher
+  health_check_grace_period_seconds = 180
+  healthcheck_healthy_threshold     = "2"
+  healthcheck_unhealthy_threshold   = "5"
+
+  # Disable cloudwatch alarms that are dependant on loadbalancer
+  cloudwatch_unhealthy_host_count_enabled = false
+  cloudwatch_healthy_host_count_enabled   = false
+  cloudwatch_response_time_enabled        = false
+  cloudwatch_http_5xx_error_count_enabled = false
+
+  # Docker container details
+  docker_registry   = var.docker_registry
+  docker_repo       = local.docker_repo
+  container_version = var.advanced_company_search_consumer_old_kafka_version
+  container_port    = local.container_port
+
+  # Service configuration
+  service_name                       = local.service_name_old_kafka
+  name_prefix                        = local.name_prefix
+  desired_task_count                 = var.desired_task_count
+  max_task_count                     = var.max_task_count
+  required_cpus                      = var.required_cpus
+  required_memory                    = var.required_memory
+  service_autoscale_enabled          = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
+  service_scaledown_schedule         = var.service_scaledown_schedule
+  service_scaleup_schedule           = var.service_scaleup_schedule
+  service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
+  use_capacity_provider              = var.use_capacity_provider
+  use_fargate                        = var.use_fargate
+  fargate_subnets                    = local.application_subnet_ids
+
+  # Cloudwatch
+  cloudwatch_alarms_enabled = false
+
+  # Service environment variable and secret configs
+  task_environment          = local.task_environment
+  task_secrets              = local.task_secrets
+  app_environment_filename  = local.app_environment_filename_old_kafka
+  use_set_environment_files = local.use_set_environment_files
+}

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -12,3 +12,7 @@ service_scaleup_schedule   = "5 6 * * ? *"
 required_cpus = 512
 required_memory = 1024
 service_autoscale_scale_out_cooldown = 600
+
+# Enable Parallel Old Kafka Service
+create_old_kafka_service = true
+advanced_company_search_consumer_old_kafka_version = "0.1.30"

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -7,3 +7,7 @@ use_set_environment_files = true
 required_cpus = 512
 required_memory = 1024
 service_autoscale_scale_out_cooldown = 600
+
+# Enable Parallel Old Kafka Service
+create_old_kafka_service = false
+advanced_company_search_consumer_old_kafka_version = "0.1.30"

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -12,3 +12,7 @@ service_scaleup_schedule   = "5 6 * * ? *"
 required_cpus = 512
 required_memory = 1024
 service_autoscale_scale_out_cooldown = 600
+
+# Enable Parallel Old Kafka Service
+create_old_kafka_service = false
+advanced_company_search_consumer_old_kafka_version = "0.1.30"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -159,6 +159,18 @@ variable "advanced_company_search_consumer_version" {
   description = "The version of the advanced-company-search-consumer container to run."
 }
 
+variable "create_old_kafka_service" {
+  type        = bool
+  description = "Whether to create the old Kafka 0.10 ECS service alongside the upgraded one."
+  default     = false
+}
+
+variable "advanced_company_search_consumer_old_kafka_version" {
+  type        = string
+  description = "The specific release tag for the old Kafka 0.10 version of the container."
+  default     = "latest"
+}
+
 variable "log_level" {
   default     = "info"
   type        = string


### PR DESCRIPTION
This PR adds dual deployment support for the advanced-company-search-consumer, allowing the old Kafka 0.10 service to run alongside the upgraded service during migration.

The old service is disabled by default (`create_old_kafka_service = false`) and can be enabled per environment by toggling the flag in the relevant profile vars file. cidev is currently enabled for testing with version `0.1.30`.