### PR TITLE
Kaf 549 upgrade to spring boot 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,15 @@ build:
 	mvn compile
 
 .PHONY: test
-test: test-unit
+test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit: clean
-	mvn verify -DexcludedGroups="integration-test"
+	mvn clean verify -Dskip.unit.tests=false -Dskip.integration.tests=true
 
 .PHONY: test-integration
 test-integration: clean
-	mvn verify -Dgroups="unit-test, integration-test"
+	mvn clean verify -Dskip.unit.tests=true -Dskip.integration.tests=false
 
 .PHONY: package
 package:

--- a/pom.xml
+++ b/pom.xml
@@ -353,14 +353,16 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Unit Testing -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <skipTests>${skip.unit.tests}</skipTests>
                     <excludes>
-                        <exclude>**/Runner.java</exclude>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                        <exclude>**/*IT.java</exclude>
                     </excludes>
                     <argLine>
                         -Dfile.encoding=UTF-8
@@ -368,14 +370,18 @@
                         --add-opens java.base/java.lang=ALL-UNNAMED
                         --add-opens java.base/java.util=ALL-UNNAMED
                     </argLine>
+                    <skipTests>${skip.unit.tests}</skipTests>
                 </configuration>
             </plugin>
+
+            <!-- Integration Testing -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${maven-failsafe-plugin.version}</version>
                 <executions>
                     <execution>
+                        <phase>integration-test</phase>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -383,19 +389,25 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <!-- See SUREFIRE-1198 -->
-                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                     <properties>
-                        <configurationParameters>
-                            cucumber.junit-platform.naming-strategy=long
-                        </configurationParameters>
+                        <property>
+                            <name>listener</name>
+                            <value>org.sonar.java.jacoco.JUnitListener</value>
+                        </property>
                     </properties>
-                    <skipITs>${skip.integration.tests}</skipITs>
                     <includes>
-                        <include>**/Runner.java</include>
+                        <include>**/*IntegrationTest.java</include>
+                        <include>**/*IT.java</include>
                     </includes>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                    <argLine>${failsafeArgLine}</argLine>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                    <skipITs>${skip.integration.tests}</skipITs>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
+
         </plugins>
     </build>
 </project>

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/AbstractKafkaIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/AbstractKafkaIntegrationTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
+package uk.gov.companieshouse.advancedcompanysearchconsumer.integration;
 
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/AbstractKafkaIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/AbstractKafkaIntegrationTest.java
@@ -10,13 +10,17 @@ import org.testcontainers.utility.DockerImageName;
 
 import uk.gov.companieshouse.advancedcompanysearchconsumer.config.TestKafkaConfig;
 
+import java.time.Duration;
+
 @Testcontainers
 @Import(TestKafkaConfig.class)
 public abstract class AbstractKafkaIntegrationTest {
 
     @Container
     protected static final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse(
-            "confluentinc/cp-kafka:latest")).withKraft();
+            "confluentinc/cp-kafka:latest"))
+            .withStartupTimeout(Duration.ofMinutes(2))
+            .withKraft();
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry registry) {

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerInvalidTopicIT.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerInvalidTopicIT.java
@@ -1,50 +1,40 @@
-package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
+package uk.gov.companieshouse.advancedcompanysearchconsumer.integration;
 
-import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.ERROR_TOPIC;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.INVALID_TOPIC;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.MAIN_TOPIC;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.RETRY_TOPIC;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
 
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
-import uk.gov.companieshouse.advancedcompanysearchconsumer.exception.NonRetryableException;
-import uk.gov.companieshouse.advancedcompanysearchconsumer.util.ServiceParameters;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.ERROR_TOPIC;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.INVALID_TOPIC;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.MAIN_TOPIC;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.RETRY_TOPIC;
 import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @SpringBootTest
 @ActiveProfiles("test_main_nonretryable")
-class ConsumerNonRetryableExceptionTest extends AbstractKafkaIntegrationTest {
+class ConsumerInvalidTopicIT extends AbstractKafkaIntegrationTest {
 
     @Autowired
     private KafkaProducer<String, ResourceChangedData> testProducer;
     @Autowired
     private KafkaConsumer<String, ResourceChangedData> testConsumer;
-
     @Autowired
     private CountDownLatch latch;
-
-    @MockitoBean
-    private Service service;
 
     @BeforeEach
     void drainKafkaTopics() {
@@ -52,9 +42,7 @@ class ConsumerNonRetryableExceptionTest extends AbstractKafkaIntegrationTest {
     }
 
     @Test
-    void testRepublishToInvalidMessageTopicIfNonRetryableExceptionThrown() throws InterruptedException {
-        //given
-        doThrow(NonRetryableException.class).when(service).processMessage(any());
+    void testPublishToInvalidMessageTopicIfInvalidDataDeserialised() throws InterruptedException {
 
         //when
         testProducer.send(new ProducerRecord<>(MAIN_TOPIC, 0, System.currentTimeMillis(), "key",
@@ -69,6 +57,5 @@ class ConsumerNonRetryableExceptionTest extends AbstractKafkaIntegrationTest {
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isZero();
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isEqualTo(1);
-        verify(service).processMessage(new ServiceParameters(UPDATE));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerNonRetryableExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerNonRetryableExceptionIT.java
@@ -1,39 +1,51 @@
-package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
+package uk.gov.companieshouse.advancedcompanysearchconsumer.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.ERROR_TOPIC;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.INVALID_TOPIC;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.MAIN_TOPIC;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.RETRY_TOPIC;
-import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ActiveProfiles;
-import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import uk.gov.companieshouse.advancedcompanysearchconsumer.exception.NonRetryableException;
+import uk.gov.companieshouse.advancedcompanysearchconsumer.service.Service;
+import uk.gov.companieshouse.advancedcompanysearchconsumer.util.ServiceParameters;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.ERROR_TOPIC;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.INVALID_TOPIC;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.MAIN_TOPIC;
+import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.RETRY_TOPIC;
 import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @SpringBootTest
 @ActiveProfiles("test_main_nonretryable")
-class ConsumerInvalidTopicTest extends AbstractKafkaIntegrationTest {
+class ConsumerNonRetryableExceptionIT extends AbstractKafkaIntegrationTest {
 
     @Autowired
     private KafkaProducer<String, ResourceChangedData> testProducer;
     @Autowired
     private KafkaConsumer<String, ResourceChangedData> testConsumer;
+
     @Autowired
     private CountDownLatch latch;
+
+    @MockitoBean
+    private Service service;
 
     @BeforeEach
     void drainKafkaTopics() {
@@ -41,7 +53,9 @@ class ConsumerInvalidTopicTest extends AbstractKafkaIntegrationTest {
     }
 
     @Test
-    void testPublishToInvalidMessageTopicIfInvalidDataDeserialised() throws InterruptedException {
+    void testRepublishToInvalidMessageTopicIfNonRetryableExceptionThrown() throws InterruptedException {
+        //given
+        doThrow(NonRetryableException.class).when(service).processMessage(any());
 
         //when
         testProducer.send(new ProducerRecord<>(MAIN_TOPIC, 0, System.currentTimeMillis(), "key",
@@ -56,5 +70,6 @@ class ConsumerInvalidTopicTest extends AbstractKafkaIntegrationTest {
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isZero();
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isEqualTo(1);
+        verify(service).processMessage(new ServiceParameters(UPDATE));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerPositiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerPositiveIT.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
+package uk.gov.companieshouse.advancedcompanysearchconsumer.integration;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -12,9 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,7 +19,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import uk.gov.companieshouse.advancedcompanysearchconsumer.exception.RetryableException;
+import uk.gov.companieshouse.advancedcompanysearchconsumer.service.Service;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.util.ServiceParameters;
 import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils;
@@ -33,14 +30,13 @@ import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtil
 import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @SpringBootTest
-@ActiveProfiles("test_main_retryable")
-class ConsumerRetryableExceptionTest extends AbstractKafkaIntegrationTest {
+@ActiveProfiles("test_main_positive")
+class ConsumerPositiveIT extends AbstractKafkaIntegrationTest {
 
     @Autowired
     private KafkaProducer<String, ResourceChangedData> testProducer;
     @Autowired
     private KafkaConsumer<String, ResourceChangedData> testConsumer;
-
     @Autowired
     private CountDownLatch latch;
 
@@ -48,28 +44,25 @@ class ConsumerRetryableExceptionTest extends AbstractKafkaIntegrationTest {
     private Service service;
 
     @BeforeEach
-    void drainKafkaTopics() {
+    void setup() {
         testConsumer.poll(Duration.ofSeconds(1));
     }
 
     @Test
-    void testRepublishToErrorTopicThroughRetryTopics() throws InterruptedException {
-        //given
-        doThrow(RetryableException.class).when(service).processMessage(any());
+    void testConsumeFromMainTopic() throws Exception {
 
-        //when
         testProducer.send(new ProducerRecord<>(MAIN_TOPIC, 0, System.currentTimeMillis(), "key",
                 UPDATE));
         if (!latch.await(5L, TimeUnit.SECONDS)) {
             fail("Timed out waiting for latch");
         }
-        ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, Duration.ofSeconds(10), 6);
+        ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, Duration.ofSeconds(10), 1);
 
         //then
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, MAIN_TOPIC)).isEqualTo(1);
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isEqualTo(4);
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isEqualTo(1);
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isZero();
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isZero();
-        verify(service, times(5)).processMessage(new ServiceParameters(UPDATE));
+        verify(service).processMessage(new ServiceParameters(UPDATE));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerRetryableExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ConsumerRetryableExceptionIT.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.advancedcompanysearchconsumer.service;
+package uk.gov.companieshouse.advancedcompanysearchconsumer.integration;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -12,6 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +22,8 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import uk.gov.companieshouse.advancedcompanysearchconsumer.exception.RetryableException;
+import uk.gov.companieshouse.advancedcompanysearchconsumer.service.Service;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.util.ServiceParameters;
 import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
 import uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils;
@@ -29,13 +34,14 @@ import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtil
 import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @SpringBootTest
-@ActiveProfiles("test_main_positive")
-class ConsumerPositiveTest extends AbstractKafkaIntegrationTest {
+@ActiveProfiles("test_main_retryable")
+class ConsumerRetryableExceptionIT extends AbstractKafkaIntegrationTest {
 
     @Autowired
     private KafkaProducer<String, ResourceChangedData> testProducer;
     @Autowired
     private KafkaConsumer<String, ResourceChangedData> testConsumer;
+
     @Autowired
     private CountDownLatch latch;
 
@@ -43,25 +49,28 @@ class ConsumerPositiveTest extends AbstractKafkaIntegrationTest {
     private Service service;
 
     @BeforeEach
-    void setup() {
+    void drainKafkaTopics() {
         testConsumer.poll(Duration.ofSeconds(1));
     }
 
     @Test
-    void testConsumeFromMainTopic() throws Exception {
+    void testRepublishToErrorTopicThroughRetryTopics() throws InterruptedException {
+        //given
+        doThrow(RetryableException.class).when(service).processMessage(any());
 
+        //when
         testProducer.send(new ProducerRecord<>(MAIN_TOPIC, 0, System.currentTimeMillis(), "key",
                 UPDATE));
         if (!latch.await(5L, TimeUnit.SECONDS)) {
             fail("Timed out waiting for latch");
         }
-        ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, Duration.ofSeconds(10), 1);
+        ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, Duration.ofSeconds(10), 6);
 
         //then
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, MAIN_TOPIC)).isEqualTo(1);
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isZero();
-        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isEqualTo(4);
+        assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isEqualTo(1);
         assertThat(TestUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isZero();
-        verify(service).processMessage(new ServiceParameters(UPDATE));
+        verify(service, times(5)).processMessage(new ServiceParameters(UPDATE));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ProducerSerializationExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/advancedcompanysearchconsumer/integration/ProducerSerializationExceptionIT.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.advancedcompanysearchconsumer.config;
+package uk.gov.companieshouse.advancedcompanysearchconsumer.integration;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -24,7 +24,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ActiveProfiles;
 
-import uk.gov.companieshouse.advancedcompanysearchconsumer.service.AbstractKafkaIntegrationTest;
 import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestConstants.UPDATE;
 import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.ERROR_TOPIC;
 import static uk.gov.companieshouse.advancedcompanysearchconsumer.utils.TestUtils.INVALID_TOPIC;
@@ -37,7 +36,7 @@ import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @SpringBootTest
 @ActiveProfiles("test_main_nonretryable")
-class ProducerSerializationExceptionTest extends AbstractKafkaIntegrationTest {
+class ProducerSerializationExceptionIT extends AbstractKafkaIntegrationTest {
 
     @Autowired
     private KafkaProducer<String, ResourceChangedData> testProducer;
@@ -56,7 +55,7 @@ class ProducerSerializationExceptionTest extends AbstractKafkaIntegrationTest {
             return Mockito.mock(AvroSerializer.class);
         }
     }
-    
+
     @BeforeEach
     void drainKafkaTopics() {
         testConsumer.poll(Duration.ofSeconds(1));


### PR DESCRIPTION
Addressed issue where makefile incorrectly dealing with unit/integration tests.
It attempted to segregate by excluding groups - no tags seem to be on the tests, so all tests would run.

Moved and renamed integration tests into own package.
Amended makefile to used skip.unit.tests and skip.integration.tests properties instead
Amended surefire and failsafe plugin config.